### PR TITLE
fix: resolve three source review findings (closes #5)

### DIFF
--- a/src/main/java/org/unlaxer/municipality/MunicipalityChange.java
+++ b/src/main/java/org/unlaxer/municipality/MunicipalityChange.java
@@ -3,6 +3,7 @@ package org.unlaxer.municipality;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * 廃置分合等情報の1レコード。
@@ -17,7 +18,44 @@ public record MunicipalityChange(
         LocalDate effectiveDate,
         String reason
 ) {
-    static MunicipalityChange fromCsvLine(String line) {
+    /**
+     * このレコードが、対象自治体（lgCode）自身の廃止・合併による消滅を表すかどうかを返す。
+     *
+     * <p>以下のいずれかのパターンに一致する場合に廃止とみなす。</p>
+     * <ul>
+     *   <li>{@code (lgCode)が...に編入} — 他市区町村に吸収合併された</li>
+     *   <li>{@code (lgCode)の...への政令指定都市施行/移行} — 政令市化に伴い旧コードが廃止された</li>
+     *   <li>{@code (lgCode)の廃止} — 直接廃止された</li>
+     * </ul>
+     *
+     * @return このレコードの lgCode が廃止されたことを示す場合 {@code true}
+     */
+    public boolean isAbolished() {
+        String code = lgCode();
+        String r = reason();
+        if (Pattern.compile("\\(" + Pattern.quote(code) + "\\)(?:が|は).*?に編入",
+                Pattern.DOTALL).matcher(r).find()) {
+            return true;
+        }
+        if (Pattern.compile("\\(" + Pattern.quote(code) + "\\)の.*?への政令指定都市(?:施行|移行)",
+                Pattern.DOTALL).matcher(r).find()) {
+            return true;
+        }
+        if (Pattern.compile("\\(" + Pattern.quote(code) + "\\)の廃止").matcher(r).find()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * CSV 行をパースして {@link MunicipalityChange} を返す。
+     *
+     * @param line CSV の1行
+     * @param lineNumber 1始まりの行番号（ログ用）
+     * @return パース成功時は非 null、列数不足時は {@code null}
+     * @throws CsvParseException パースは成功したが値の変換に失敗した場合
+     */
+    static MunicipalityChange fromCsvLine(String line, int lineNumber) throws CsvParseException {
         String[] cols = parseCsv(line);
         if (cols.length < 8) return null;
         try {
@@ -32,7 +70,28 @@ public record MunicipalityChange(
                     unquote(cols[7])
             );
         } catch (Exception e) {
+            throw new CsvParseException(lineNumber, line, e);
+        }
+    }
+
+    /** 後方互換用のシグネチャ（行番号なし）。内部テストから呼ばれる。 */
+    static MunicipalityChange fromCsvLine(String line) {
+        try {
+            return fromCsvLine(line, -1);
+        } catch (CsvParseException e) {
             return null;
+        }
+    }
+
+    /** CSV パース時の変換エラーを表す例外。 */
+    static final class CsvParseException extends Exception {
+        final int lineNumber;
+        final String rawLine;
+
+        CsvParseException(int lineNumber, String rawLine, Throwable cause) {
+            super("CSV parse error at line " + lineNumber + ": " + cause.getMessage(), cause);
+            this.lineNumber = lineNumber;
+            this.rawLine = rawLine;
         }
     }
 

--- a/src/main/java/org/unlaxer/municipality/MunicipalityHistory.java
+++ b/src/main/java/org/unlaxer/municipality/MunicipalityHistory.java
@@ -61,11 +61,31 @@ public class MunicipalityHistory {
     }
 
     private static void loadFromReader(BufferedReader reader, List<MunicipalityChange> changes) throws IOException {
-        String line = reader.readLine(); // skip header
+        reader.readLine(); // skip header
+        String line;
+        int lineNumber = 1; // header was line 1
+        int skipped = 0;
         while ((line = reader.readLine()) != null) {
+            lineNumber++;
             if (line.isBlank()) continue;
-            MunicipalityChange change = MunicipalityChange.fromCsvLine(line);
-            if (change != null) changes.add(change);
+            try {
+                MunicipalityChange change = MunicipalityChange.fromCsvLine(line, lineNumber);
+                if (change == null) {
+                    skipped++;
+                    System.err.printf("[municipality-history] WARN: skipped line %d (too few columns): %s%n",
+                            lineNumber, line.length() > 120 ? line.substring(0, 120) + "..." : line);
+                } else {
+                    changes.add(change);
+                }
+            } catch (MunicipalityChange.CsvParseException e) {
+                skipped++;
+                System.err.printf("[municipality-history] WARN: skipped line %d (%s): %s%n",
+                        e.lineNumber, e.getCause().getClass().getSimpleName(),
+                        e.rawLine.length() > 120 ? e.rawLine.substring(0, 120) + "..." : e.rawLine);
+            }
+        }
+        if (skipped > 0) {
+            System.err.printf("[municipality-history] WARN: %d line(s) skipped during CSV load.%n", skipped);
         }
     }
 
@@ -104,6 +124,10 @@ public class MunicipalityHistory {
      * かつ同一 lgCode の次のレコードの {@code effectiveDate} より前（または次のレコードがない）。
      * すなわち、その日時点で最も新しい変遷レコードを持つ自治体を返す。</p>
      *
+     * <p>ただし、直近レコードの {@link MunicipalityChange#isAbolished()} が {@code true} の場合
+     * （他自治体への吸収合併・政令指定都市化による旧コード廃止など）は、
+     * 当該 lgCode はその日時点で廃止済みとみなし、結果から除外する。</p>
+     *
      * @param date 基準日
      * @return 指定日時点で有効な自治体変遷レコードのリスト（lgCode ごとに最新の1件）
      */
@@ -114,6 +138,7 @@ public class MunicipalityHistory {
                         .max(Comparator.comparing(MunicipalityChange::effectiveDate))
                         .orElse(null))
                 .filter(Objects::nonNull)
+                .filter(c -> !c.isAbolished())
                 .sorted(Comparator.comparing(MunicipalityChange::lgCode))
                 .toList();
     }
@@ -152,20 +177,25 @@ public class MunicipalityHistory {
     /**
      * e-Stat API の appId を返す。
      *
-     * <p>優先順位:</p>
-     * <ol>
-     *   <li>環境変数 {@code ESTAT_APP_ID} が設定されていればその値</li>
-     *   <li>フォールバック: CLAUDE.md に記載のデフォルト appId</li>
-     * </ol>
+     * <p>環境変数 {@code ESTAT_APP_ID} を必須とする。未設定の場合は
+     * {@link IllegalStateException} をスローする。</p>
+     *
+     * <p>e-Stat の appId は
+     * <a href="https://www.e-stat.go.jp/api/">https://www.e-stat.go.jp/api/</a>
+     * から取得できる。取得した値を環境変数 {@code ESTAT_APP_ID} に設定してから呼び出すこと。</p>
      *
      * @return e-Stat appId 文字列
+     * @throws IllegalStateException 環境変数 {@code ESTAT_APP_ID} が設定されていない場合
      */
     public static String estatAppId() {
         String envId = System.getenv("ESTAT_APP_ID");
         if (envId != null && !envId.isBlank()) {
             return envId;
         }
-        return "24edfb042993e87548e75f8e26f6f5421646a6fe";
+        throw new IllegalStateException(
+                "環境変数 ESTAT_APP_ID が設定されていません。" +
+                "https://www.e-stat.go.jp/api/ で appId を取得し、" +
+                "ESTAT_APP_ID 環境変数に設定してください。");
     }
 
     // CLI

--- a/src/test/java/org/unlaxer/municipality/MunicipalityHistoryQueryTest.java
+++ b/src/test/java/org/unlaxer/municipality/MunicipalityHistoryQueryTest.java
@@ -195,14 +195,22 @@ class MunicipalityHistoryQueryTest {
 
     @Test
     void estatAppId_hasExpectedLength() {
-        String id = MunicipalityHistory.estatAppId();
-        // e-Stat appId は 40 文字の hex 文字列
-        assertTrue(id.length() >= 30, "appId should be reasonably long: " + id);
+        // ESTAT_APP_ID が設定されている環境でのみ値を検証する
+        String envId = System.getenv("ESTAT_APP_ID");
+        if (envId != null && !envId.isBlank()) {
+            String id = MunicipalityHistory.estatAppId();
+            // e-Stat appId は 40 文字の hex 文字列
+            assertTrue(id.length() >= 30, "appId should be reasonably long: " + id);
+        }
     }
 
     @Test
     void estatAppId_containsOnlyAlphanumeric() {
-        String id = MunicipalityHistory.estatAppId();
-        assertTrue(id.matches("[a-zA-Z0-9]+"), "appId should be alphanumeric: " + id);
+        // ESTAT_APP_ID が設定されている環境でのみ値を検証する
+        String envId = System.getenv("ESTAT_APP_ID");
+        if (envId != null && !envId.isBlank()) {
+            String id = MunicipalityHistory.estatAppId();
+            assertTrue(id.matches("[a-zA-Z0-9]+"), "appId should be alphanumeric: " + id);
+        }
     }
 }

--- a/src/test/java/org/unlaxer/municipality/MunicipalityHistoryTest.java
+++ b/src/test/java/org/unlaxer/municipality/MunicipalityHistoryTest.java
@@ -139,9 +139,24 @@ class MunicipalityHistoryTest {
     // ---- estatAppId ----
 
     @Test
-    void estatAppId_defaultIsNotBlank() {
-        String id = MunicipalityHistory.estatAppId();
-        assertNotNull(id);
-        assertFalse(id.isBlank());
+    void estatAppId_returnsEnvVarWhenSet() {
+        // ESTAT_APP_ID が設定されている環境でのみ値を検証する
+        String envId = System.getenv("ESTAT_APP_ID");
+        if (envId != null && !envId.isBlank()) {
+            String id = MunicipalityHistory.estatAppId();
+            assertNotNull(id);
+            assertFalse(id.isBlank());
+            assertEquals(envId, id);
+        }
+    }
+
+    @Test
+    void estatAppId_throwsWhenEnvVarNotSet() {
+        // ESTAT_APP_ID が未設定のとき IllegalStateException がスローされることを確認する
+        String envId = System.getenv("ESTAT_APP_ID");
+        if (envId == null || envId.isBlank()) {
+            assertThrows(IllegalStateException.class, MunicipalityHistory::estatAppId,
+                    "ESTAT_APP_ID が未設定のとき IllegalStateException がスローされるべき");
+        }
     }
 }


### PR DESCRIPTION
Closes #5

## Summary

- **activeAt() returns abolished municipalities** (`MunicipalityHistory.java:110`): Added `MunicipalityChange#isAbolished()` which detects whether a change record represents the lgCode itself being absorbed into another municipality (via `に編入` pattern), abolished on 政令指定都市 migration, or directly廃止. `activeAt()` now filters out any code whose latest record up to the query date is an abolishment record.

- **Hardcoded e-Stat app ID fallback** (`MunicipalityHistory.java:163`): Removed the hardcoded owner-specific app ID. `estatAppId()` now throws `IllegalStateException` when `ESTAT_APP_ID` env var is not set, forcing callers to supply their own registered key.

- **Silent CSV parse failure** (`MunicipalityChange.java:20`): Introduced a checked `CsvParseException` inner class. `fromCsvLine(line, lineNumber)` now throws it on value-conversion errors instead of silently returning null. `loadFromReader()` catches both null (too few columns) and `CsvParseException`, logging line number, exception type, and truncated raw line to stderr. A final summary of total skip count is emitted after the load completes.

## Test plan

- [x] All 43 existing tests pass (`mvn test`)
- [x] `estatAppId_throwsWhenEnvVarNotSet` verifies the new exception behavior
- [x] `estatAppId_returnsEnvVarWhenSet` verifies it works when the env var is present
- [x] `activeAt_lgCodeUniqueness` and other `activeAt_*` tests continue to pass with the abolishment filter
- [x] `fromCsvLine_returnsNullForTooFewColumns` and `fromCsvLine_returnsNullForUnparsableDate` tests remain passing via the backward-compat no-arg overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)